### PR TITLE
Fix argument_spec type for members

### DIFF
--- a/library/comware_portchannel.py
+++ b/library/comware_portchannel.py
@@ -202,7 +202,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             group=dict(required=True, type='str'),
-            members=dict(required=False),
+            members=dict(required=False, type='list'),
             mode=dict(required=False, choices=['static', 'dynamic']),
             type=dict(required=False, choices=['bridged', 'routed']),
             lacp_mode=dict(required=False, choices=['active', 'passive']),


### PR DESCRIPTION
Module fails in Ansible 2.1.1 if type is not specified in argument_spec as isinstance(members, list) does not return true then.
